### PR TITLE
Fix comment for task V

### DIFF
--- a/src/v_collections/I_Partition_.kt
+++ b/src/v_collections/I_Partition_.kt
@@ -3,7 +3,7 @@ package v_collections
 fun example8() {
     val numbers = listOf(1, 3, -4, 2, -11)
 
-    //the details (how multi-assignment works) you'll found in 'Conventions' task later
+    //the details (how multi-assignment works) were explained in 'Conventions' task earlier
     val (positive, negative) = numbers.partition { it > 0 }
 
     positive == listOf(1, 3, 2)


### PR DESCRIPTION
It seems to me that this convention was explained in part II while the comment itself is written in part V. It was earlier and will not be later, right? :)
