### PR TITLE
Fix package name of first koan

### DIFF
--- a/src/i_introduction/_0_Hello_World/HelloWorld.kt
+++ b/src/i_introduction/_0_Hello_World/HelloWorld.kt
@@ -1,4 +1,4 @@
-package i_introduction._0_Hello_World.Hello
+package i_introduction._0_Hello_World
 
 import util.TODO
 import util.doc0

--- a/test/i_introduction/_0_Hello_World/_00_Start.kt
+++ b/test/i_introduction/_0_Hello_World/_00_Start.kt
@@ -1,4 +1,4 @@
-package i_introduction._0_Hello_World.Hello
+package i_introduction._0_Hello_World
 
 import org.junit.Assert.assertEquals
 import org.junit.Test


### PR DESCRIPTION
This package name aligns with the project directory structure.
Before Kotlin would generate extra warnings for mismatched package name.