### PR TITLE
Fix order of expected and actual test values

### DIFF
--- a/test/ii_collections/_13_Introduction.kt
+++ b/test/ii_collections/_13_Introduction.kt
@@ -7,6 +7,6 @@ import org.junit.Test
 
 class _13_Introduction {
     @Test fun testSetOfCustomers() {
-        assertEquals(shop.getSetOfCustomers(), customers.values.toSet())
+        assertEquals(customers.values.toSet(), shop.getSetOfCustomers())
     }
 }


### PR DESCRIPTION
This fixes the order of the expected and actual values in the getSetOfCustomers() test.
