### PR TITLE
Improve `getCellColor` naming of arguments

### DIFF
--- a/src/v_builders/_39_HtmlBuilders.kt
+++ b/src/v_builders/_39_HtmlBuilders.kt
@@ -6,7 +6,7 @@ import v_builders.data.getProducts
 import v_builders.htmlLibrary.*
 
 fun getTitleColor() = "#b9c9fe"
-fun getCellColor(index: Int, row: Int) = if ((index + row) %2 == 0) "#dce4ff" else "#eff2ff"
+fun getCellColor(row: Int, column: Int) = if ((row + column) %2 == 0) "#dce4ff" else "#eff2ff"
 
 fun todoTask39(): Nothing = TODO(
     """


### PR DESCRIPTION
* `index` is actually `row`
* `row` is actually `column`