### PR TITLE
Catch partial regexes in test cases

### DIFF
--- a/test/i_introduction/_5_String_Templates/_05_String_Templates.kt
+++ b/test/i_introduction/_5_String_Templates/_05_String_Templates.kt
@@ -7,14 +7,14 @@ import java.util.regex.Pattern
 
 class _05_String_Templates() {
     @Test fun match() {
-        assertTrue(Pattern.compile(task5()).matcher("Douglas Adams (11 MAR 1952)").find())
+        assertTrue("11 MAR 1952".matches(task5().toRegex()))
     }
 
     @Test fun match1() {
-        assertTrue(Pattern.compile(task5()).matcher("Stephen Fry (24 AUG 1957)").find())
+        assertTrue("24 AUG 1957".matches(task5().toRegex()))
     }
 
     @Test fun doNotMatch() {
-        assertFalse(Pattern.compile(task5()).matcher("Stephen Fry (24 RRR 1957)").find())
+        assertFalse("24 RRR 1957".matches(task5().toRegex()))
     }
 }


### PR DESCRIPTION
Previous test cases only required regex to match part of the test string, so would accept regexes such as """\d{2} $month \d{3}""" or even """$month""".