### PR TITLE
fix MyDate.toMillis: set hour, minute, second & microsecond to 0

### DIFF
--- a/src/iv_properties/_35_HowDelegatesWork.kt
+++ b/src/iv_properties/_35_HowDelegatesWork.kt
@@ -35,7 +35,8 @@ class EffectiveDate<R> : ReadWriteProperty<R, MyDate> {
 
 fun MyDate.toMillis(): Long {
     val c = Calendar.getInstance()
-    c.set(year, month, dayOfMonth)
+    c.set(year, month, dayOfMonth, 0, 0, 0)
+    c.set(Calendar.MILLISECOND, 0)
     return c.timeInMillis
 }
 

--- a/test/iv_properties/_35_Delegates_How_It_Works.kt
+++ b/test/iv_properties/_35_Delegates_How_It_Works.kt
@@ -11,5 +11,7 @@ class _35_Delegates_How_It_Works {
         assertEquals(2014, d.date.year)
         assertEquals(1, d.date.month)
         assertEquals(13, d.date.dayOfMonth)
+        assertEquals(d.date, 1392220800000.toDate())
+        assertEquals(1392220800000, d.date.toMillis())
     }
 }


### PR DESCRIPTION
Get not the same result each time to run MyDate.toMillis. Because the 'c' has the current hour, minute, second & microsecond, which should be set to 0.

I also add two assert in the unit test.