### PR TITLE
Made assertions introduced by pull request #71 work regardless of TimeZone.

### DIFF
--- a/test/iv_properties/_35_Delegates_How_It_Works.kt
+++ b/test/iv_properties/_35_Delegates_How_It_Works.kt
@@ -3,15 +3,20 @@ package iv_properties
 import iii_conventions.MyDate
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import java.util.*
 
 class _35_Delegates_How_It_Works {
     @Test fun testDate() {
         val d = D()
         d.date = MyDate(2014, 1, 13)
+        val c = Calendar.getInstance();
+        c.set(2014, 1, 13, 0, 0, 0)
+        c.set(Calendar.MILLISECOND, 0)
+
         assertEquals(2014, d.date.year)
         assertEquals(1, d.date.month)
         assertEquals(13, d.date.dayOfMonth)
-        assertEquals(d.date, 1392220800000.toDate())
-        assertEquals(1392220800000, d.date.toMillis())
+        assertEquals(c.timeInMillis.toDate(), d.date)
+        assertEquals(c.timeInMillis, d.date.toMillis())
     }
 }


### PR DESCRIPTION
The pull request #71 introduced two new assertions that do not work properly if your JVM is not running on a UTC-8 timezone.
Also the order of the first assertion parameters were inverted (actual, expected) instead of the correct (expected, actual), the error message was misleading.
This commit changes only the test class keeping the rest of the contributions from icejoywoo untouched.