### PR TITLE
Remove extra space

### DIFF
--- a/src/v_builders/html.kt
+++ b/src/v_builders/html.kt
@@ -15,7 +15,7 @@ open class Tag(val name: String) {
 }
 
 class Attribute(val name : String, val value : String) {
-    override fun toString() = """$name="$value" """
+    override fun toString() = """$name="$value""""
 }
 
 fun <T: Tag> T.set(name: String, value: String?): T {


### PR DESCRIPTION
This optional space is not required, is a bad idea anyway for the attribute to know about that extra space required at the tag level.