### PR TITLE
Clearer instructions for 'Named Arguments' exercise

### DIFF
--- a/src/i_introduction/_2_Named_Arguments/NamedArguments.kt
+++ b/src/i_introduction/_2_Named_Arguments/NamedArguments.kt
@@ -15,7 +15,8 @@ fun usage() {
 fun todoTask2(): Nothing = TODO(
     """
         Task 2.
-        Implement the same logic as in 'task1' again through the library method 'joinToString()'.
+        Implement the same logic as in 'task1'. This time use the library method 'joinToString()',
+        instead of the converted Java code.
         Specify only two of the 'joinToString' arguments.
     """,
     documentation = doc2(),


### PR DESCRIPTION
Hi I'm not sure if you're taking pull requests for this, but I was confused about the wording on the "Name Arguments" koan (`NameArguments.kt`). You mention the `joinToString()` collection method, used in `JavaToKotlinConverter.kt`, but because we're converting from Java, this method is never used, not even in your implementation of the solution to the exercise.

The wording in the exercise NameArguments is my suggestion to make the instructions more understandable.

If you're not taking pull requests, or feel that my wording reveals too much about what needs to be done, that fine too, just thought I'd see :)