### PR TITLE
Fix inconsistent error message for (32 Properties) suit unit test

### DIFF
--- a/test/iv_properties/_32_Properties.kt
+++ b/test/iv_properties/_32_Properties.kt
@@ -9,7 +9,7 @@ class _32_Properties {
         q.propertyWithCounter = 14
         q.propertyWithCounter = 21
         q.propertyWithCounter = 32
-        assertEquals("The property q.changeCounter should contain the number of assignments to q.propertyWithCounter:",
+        assertEquals("The property q.counter should contain the number of assignments to q.propertyWithCounter:",
                 3, q.counter)
         // Here we have to use !! due to false smart cast impossible
         assertEquals("The property q.propertyWithCounter should be set:", 32, q.propertyWithCounter!!)


### PR DESCRIPTION
Update unit test error message according to correct name of property`counter`.