### PR TITLE
Fix inconsistent unit tests for 38 (The Function Apply) suite.

### DIFF
--- a/test/v_builders/_38_The_Function_Apply.kt
+++ b/test/v_builders/_38_The_Function_Apply.kt
@@ -6,24 +6,24 @@ import java.util.*
 
 class _38_The_Function_Apply {
     @Test fun testBuildString() {
-        val expected = buildString()
-        val actual = StringBuilder().apply {
+        val expected = StringBuilder().apply {
             append("Numbers: ")
             for (i in 1..10) {
                 append(i)
             }
         }.toString()
+        val actual = buildString()
         assertEquals("String should be built:", expected, actual)
     }
 
     @Test fun testBuildMap() {
-        val expected = buildMap()
-        val actual = HashMap<Int, String>().apply {
+        val expected = HashMap<Int, String>().apply {
             put(0, "0")
             for (i in 1..10) {
                 put(i, "$i")
             }
         }
+        val actual = buildMap()
         assertEquals("Map should be filled with the right values", expected, actual)
     }
 }


### PR DESCRIPTION
Reason: Expected and actual are mixed up.