### PR TITLE
Change documentation link protocol from http to https.

### DIFF
--- a/src/util/LinksToDocumentation.kt
+++ b/src/util/LinksToDocumentation.kt
@@ -1,47 +1,47 @@
 package util
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/basic-syntax.html#defining-functions">Function syntax</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/basic-syntax.html#defining-functions">Function syntax</a>
  */
 fun doc0() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/functions.html#default-arguments">Default and named arguments</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/functions.html#default-arguments">Default and named arguments</a>
  */
 fun doc2() {}
 
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/lambdas.html">Lambdas</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/lambdas.html">Lambdas</a>
  */
 fun doc4() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/basic-types.html#string-literals">String literals and string templates</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/basic-types.html#string-literals">String literals and string templates</a>
  */
 fun doc5() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/classes.html">Classes</a>,
-<a href="http://kotlinlang.org/docs/reference/properties.html">Properties</a>,
+ * @see <a href="https://kotlinlang.org/docs/reference/classes.html">Classes</a>,
+<a href="https://kotlinlang.org/docs/reference/properties.html">Properties</a>,
 <a href="https://kotlinlang.org/docs/reference/data-classes.html">Data classes</a>
  */
 fun doc6() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/null-safety.html">Null safety and safe calls</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/null-safety.html">Null safety and safe calls</a>
  */
 fun doc7() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/typecasts.html#smart-casts">Smart casts</a>,
- *      <a href="http://kotlinlang.org/docs/reference/control-flow.html#when-expression">When</a>,
+ * @see <a href="https://kotlinlang.org/docs/reference/typecasts.html#smart-casts">Smart casts</a>,
+ *      <a href="https://kotlinlang.org/docs/reference/control-flow.html#when-expression">When</a>,
  *      <a href="https://kotlinlang.org/docs/reference/sealed-classes.html">Sealed classes</a>
  */
 fun doc8() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/extensions.html">Extension functions</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/extensions.html">Extension functions</a>
  */
 fun doc9() {}
 
@@ -57,37 +57,37 @@ fun doc11() {}
 
 /**
  * @see <a href="https://kotlinlang.org/docs/reference/collections.html">Collections</a>,
- * <a href="http://blog.jetbrains.com/kotlin/2012/09/kotlin-m3-is-out/#Collections">Hierarchy illustration</a>
+ * <a href="https://blog.jetbrains.com/kotlin/2012/09/kotlin-m3-is-out/#Collections">Hierarchy illustration</a>
  */
 fun doc12() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/operator-overloading.html">Operator overloading</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/operator-overloading.html">Operator overloading</a>
  */
 fun doc25() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/control-flow.html#for-loops">For-loop</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/control-flow.html#for-loops">For-loop</a>
  */
 fun doc28() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/ranges.html">Ranges</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/ranges.html">Ranges</a>
  */
 fun doc26() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/multi-declarations.html#multi-declarations">Destructuring declarations</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/multi-declarations.html#multi-declarations">Destructuring declarations</a>
  */
 fun doc30() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/properties.html#properties-and-fields">Properties</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/properties.html#properties-and-fields">Properties</a>
  */
 fun doc32() {}
 
 /**
- * @see <a href="http://kotlinlang.org/docs/reference/delegated-properties.html">Delegated Properties</a>
+ * @see <a href="https://kotlinlang.org/docs/reference/delegated-properties.html">Delegated Properties</a>
  */
 fun doc34() {}
 


### PR DESCRIPTION
Some place uses `https` while most other place use `http`.
Make it unified.