### PR TITLE
Fix leap year definition

### DIFF
--- a/src/iii_conventions/n30DestructuringDeclarations.kt
+++ b/src/iii_conventions/n30DestructuringDeclarations.kt
@@ -17,6 +17,8 @@ fun isLeapDay(date: MyDate): Boolean {
     todoTask30()
 //    val (year, month, dayOfMonth) = date
 //
+//    fun isLeapYear(year: Int): Boolean = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
+//
 //    // 29 February of a leap year
-//    return year % 4 == 0 && month == 2 && dayOfMonth == 29
+//    return isLeapYear(year) && month == 2 && dayOfMonth == 29
 }


### PR DESCRIPTION
In the Gregorian calendar three criteria must be taken into account to identify leap years:
* The year can be evenly divided by 4;
* If the year can be evenly divided by 100, it is NOT a leap year, unless;
* The year is also evenly divisible by 400. Then it is a leap year.

This means that in the Gregorian calendar, the years 2000 and 2400 are leap years, while 1800, 1900, 2100, 2200, 2300 and 2500 are NOT leap years.

via https://www.timeanddate.com/date/leapyear.html