### PR TITLE
Using latest Gradle release

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2.1-all.zip


### PR DESCRIPTION
This fixes the "Could not determine java version from '9.0.0.15'"
error in IntelliJ when using Java 9 zulu.

Found the solution here: https://discuss.gradle.org/t/could-not-determine-java-version-from-9-0-1/24457/3