### PR TITLE
Removes the implementation from the test

### DIFF
--- a/test/iii_conventions/N31InvokeKtTest.kt
+++ b/test/iii_conventions/N31InvokeKtTest.kt
@@ -19,7 +19,4 @@ class N31InvokeKtTest {
         testInvokable(5) { it()()()()() }
         testInvokable(0) { it }
     }
-
-    operator fun Invokable.invoke(): Nothing = todoTask31()
-    fun Invokable.getNumberOfInvocations(): Nothing = todoTask31()
 }


### PR DESCRIPTION
The test was overwriting the students' solution, forcing them to update the test to make it work.