### PR TITLE
Use spread operator for named vararg

### DIFF
--- a/test/ii_collections/N23CompoundTasksKtTest.kt
+++ b/test/ii_collections/N23CompoundTasksKtTest.kt
@@ -12,7 +12,7 @@ class N23CompoundTasksKtTest {
     @Test fun testMostExpensiveDeliveredProduct() {
         val testShop = shop("test shop for 'most expensive delivered product'",
                 customer(lucas, Canberra,
-                        order(isDelivered = false, products = idea),
+                        order(isDelivered = false, products = *arrayOf(idea)),
                         order(reSharper)
                 )
         )


### PR DESCRIPTION
This was giving the warning 'Assigning single elements to varargs in named form is deprecated.' in IntelliJ IDEA.