### PR TITLE
Fix inconsistent encoding of months

### DIFF
--- a/src/iii_conventions/_30_DestructuringDeclarations.kt
+++ b/src/iii_conventions/_30_DestructuringDeclarations.kt
@@ -18,5 +18,5 @@ fun isLeapDay(date: MyDate): Boolean {
 //    val (year, month, dayOfMonth) = date
 //
 //    // 29 February of a leap year
-//    return year % 4 == 0 && month == 2 && dayOfMonth == 29
+//    return year % 4 == 0 && month == 1 && dayOfMonth == 29
 }

--- a/test/iii_conventions/_30_Multi_Assignment.kt
+++ b/test/iii_conventions/_30_Multi_Assignment.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 
 class _30_Multi_Assignment {
     @Test fun testIsLeapDay() {
-        assertTrue(isLeapDay(MyDate(2016, 2, 29)))
-        assertFalse(isLeapDay(MyDate(2015, 2, 29)))
+        assertTrue(isLeapDay(MyDate(2016, 1, 29)))
+        assertFalse(isLeapDay(MyDate(2015, 1, 29)))
     }
 }


### PR DESCRIPTION
Resolve #110 (Mixed up encoding of months in task 30) by using value of `1` to reflect `February`