### PR TITLE
Changed from named single elements in varargs

### DIFF
--- a/src/i_introduction/_0_Hello_World/n00Start.kt
+++ b/src/i_introduction/_0_Hello_World/n00Start.kt
@@ -20,8 +20,8 @@ fun todoTask0(): Nothing = TODO(
 
         Let's start! Make the function 'task0' return "OK". Note that you can return expression directly.
     """,
-    documentation = doc0(),
-    references = { task0(); "OK" }
+    doc0(),
+    { task0(); "OK" }
 )
 
 fun task0(): String {


### PR DESCRIPTION
IntelliJ IDEA 2017.3 gives this warning message:

    Kotlin: Assigning single elements to varargs in named form is deprecated

The warning is removed if the names of the single arguments are removed.

If this pull request is accepted, I will make another one which removes the same warning in other files.