### PR TITLE
add missing config to use JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,3 +26,7 @@ dependencies {
     compile 'com.google.guava:guava:16.0'
     testCompile 'org.junit.jupiter:junit-jupiter:5.4.0'
 }
+
+test {
+    useJUnitPlatform()
+}


### PR DESCRIPTION
I was getting a `No tests found for given includes: [i_*](--tests filter)` error when running `$ ./gradlew test --tests i_*`, although `$ ./gradlew test` shows successful build.

It seems that gradle was unable to detect test classes because of the switch to JUnit 5.  Adding these 3 lines according to the [gradle doc](https://docs.gradle.org/5.2.1/userguide/java_testing.html#using_junit5) fixed the issue.